### PR TITLE
docs(spec): add CEP-23 and CEP-24 draft specifications

### DIFF
--- a/src/content/docs/spec/ceps/cep-23.md
+++ b/src/content/docs/spec/ceps/cep-23.md
@@ -27,7 +27,7 @@ Not all servers want a social presence. Therefore, profile publication is explic
 
 ### NIP-01 Metadata Content
 
-When publishing server profile metadata, implementations MUST use `kind:0` and a JSON `content` payload compatible with NIP-01 metadata conventions.
+When publishing server profile metadata, implementations MUST use `kind:0`. The `content` field MUST be a string containing stringified JSON compatible with NIP-01 metadata conventions.
 
 Common fields include:
 
@@ -95,6 +95,10 @@ This CEP is additive and introduces no breaking changes:
 - Servers not publishing `kind:0` continue to work unchanged
 - Existing CEP-6 discovery remains valid
 - Clients can progressively enhance rendering when `kind:0` is present
+
+## Reference Implementation
+
+A reference implementation of this metadata publishing can be found in the [ContextVM SDK announcement manager](https://github.com/ContextVM/sdk/blob/master/src/transport/nostr-server/announcement-manager.ts).
 
 ## Dependencies
 

--- a/src/content/docs/spec/ceps/cep-23.md
+++ b/src/content/docs/spec/ceps/cep-23.md
@@ -1,0 +1,101 @@
+---
+title: CEP-23 Server Profile Metadata
+description: Optional kind 0 profile metadata for server social identity on Nostr
+---
+
+# Server Profile Metadata
+
+**Status:** Draft
+**Author:** @contextvm-org
+**Type:** Standards Track
+
+## Abstract
+
+This CEP defines an optional server profile mechanism using NIP-01 metadata events (`kind:0`).
+
+ContextVM servers MAY publish `kind:0` metadata signed by the same server keypair used for protocol operation and announcements. This allows a server to establish a recognizable social identity in the broader Nostr ecosystem while preserving the existing capability-announcement model.
+
+## Motivation
+
+`kind:11316` announcements (CEP-6) are capability catalogs. They are optimized for machine and protocol discovery, not for social identity rendering.
+
+Nostr clients already treat `kind:0` as the canonical identity primitive and render it in user-facing profiles. Reusing this standard primitive allows server operators to present human-friendly identity metadata (name, avatar, website, etc.) without inventing a new profile format.
+
+Not all servers want a social presence. Therefore, profile publication is explicitly opt-in.
+
+## Specification
+
+### NIP-01 Metadata Content
+
+When publishing server profile metadata, implementations MUST use `kind:0` and a JSON `content` payload compatible with NIP-01 metadata conventions.
+
+Common fields include:
+
+- `name`
+- `about`
+- `picture`
+- `banner`
+- `website`
+- `nip05`
+- `lud16`
+
+Example:
+
+```json
+{
+  "kind": 0,
+  "pubkey": "<server-pubkey>",
+  "content": "{\"name\":\"Example Server\",\"about\":\"Public MCP provider\",\"picture\":\"https://example.com/avatar.png\",\"website\":\"https://example.com\"}",
+  "tags": []
+}
+```
+
+### Optional ContextVM Marker
+
+Servers MAY include a `contextvm` field in the metadata JSON content (for example, `"contextvm": true`) as an ecosystem hint.
+
+This field is optional and non-normative. Clients MUST NOT require it for identifying a ContextVM server.
+
+### Optional Public Notes
+
+Servers MAY additionally publish `kind:1` text notes for public updates, changelogs, or operator communication.
+
+This CEP does not define special semantics for those notes beyond existing Nostr conventions.
+
+### Relationship to CEP-6 Announcements
+
+`kind:11316` and `kind:0` serve different roles and are complementary:
+
+- `kind:11316` (CEP-6): capability advertisement and protocol metadata
+- `kind:0` (this CEP): identity metadata for social/client rendering
+
+Servers SHOULD publish both using the same pubkey when both are enabled.
+
+Clients that discover a server through `kind:11316` SHOULD also fetch `kind:0` for richer profile presentation.
+
+### Publishing Behavior
+
+Profile publication is opt-in.
+
+When configured, servers SHOULD publish their `kind:0` profile metadata at startup and MAY republish on profile changes according to replaceable-event behavior.
+
+## Client Rendering
+
+When both profile sources are available:
+
+- Clients SHOULD prefer `kind:0` metadata for profile presentation
+- Clients SHOULD use `kind:11316` tags as fallback when `kind:0` is absent
+
+This preference order allows clients to display richer identity information while maintaining compatibility with announcement-only servers.
+
+## Backward Compatibility
+
+This CEP is additive and introduces no breaking changes:
+
+- Servers not publishing `kind:0` continue to work unchanged
+- Existing CEP-6 discovery remains valid
+- Clients can progressively enhance rendering when `kind:0` is present
+
+## Dependencies
+
+- [CEP-6: Public Server Announcements](/spec/ceps/cep-6)

--- a/src/content/docs/spec/ceps/cep-23.md
+++ b/src/content/docs/spec/ceps/cep-23.md
@@ -1,9 +1,9 @@
 ---
-title: CEP-23 Server Profile Metadata
-description: Optional kind 0 profile metadata for server social identity on Nostr
+title: CEP-23 Server Profile Metadata and Social Communications
+description: Optional kind 0 metadata and kind 1 notes for server social presence on Nostr
 ---
 
-# Server Profile Metadata
+# Server Profile Metadata and Social Communications
 
 **Status:** Draft
 **Author:** @contextvm-org
@@ -11,17 +11,17 @@ description: Optional kind 0 profile metadata for server social identity on Nost
 
 ## Abstract
 
-This CEP defines an optional server profile mechanism using NIP-01 metadata events (`kind:0`).
+This CEP defines optional social presence primitives for ContextVM servers using standard Nostr events: `kind:0` profile metadata and `kind:1` notes for social communications.
 
-ContextVM servers MAY publish `kind:0` metadata signed by the same server keypair used for protocol operation and announcements. This allows a server to establish a recognizable social identity in the broader Nostr ecosystem while preserving the existing capability-announcement model.
+ContextVM servers MAY publish `kind:0` metadata signed by the same server keypair used for protocol operation and announcements. Servers MAY also publish regular `kind:1` notes for social announcements, public updates, changelogs, and operator communication. This enables social presence in the broader Nostr ecosystem while preserving the existing capability-announcement model.
 
 ## Motivation
 
-`kind:11316` announcements (CEP-6) are capability catalogs. They are optimized for machine and protocol discovery, not for social identity rendering.
+CEP-6 announcements are capability catalogs. They are optimized for machine and protocol discovery, not for social identity rendering.
 
 Nostr clients already treat `kind:0` as the canonical identity primitive and render it in user-facing profiles. Reusing this standard primitive allows server operators to present human-friendly identity metadata (name, avatar, website, etc.) without inventing a new profile format.
 
-Not all servers want a social presence. Therefore, profile publication is explicitly opt-in.
+Not all servers want a social presence. Therefore, profile metadata publication is explicitly opt-in, and publishing `kind:1` notes for social announcements or communications is also optional.
 
 ## Specification
 
@@ -50,13 +50,7 @@ Example:
 }
 ```
 
-### Optional ContextVM Marker
-
-Servers MAY include a `contextvm` field in the metadata JSON content (for example, `"contextvm": true`) as an ecosystem hint.
-
-This field is optional and non-normative. Clients MUST NOT require it for identifying a ContextVM server.
-
-### Optional Public Notes
+### Optional Social Communications
 
 Servers MAY additionally publish `kind:1` text notes for public updates, changelogs, or operator communication.
 
@@ -69,24 +63,7 @@ This CEP does not define special semantics for those notes beyond existing Nostr
 - `kind:11316` (CEP-6): capability advertisement and protocol metadata
 - `kind:0` (this CEP): identity metadata for social/client rendering
 
-Servers SHOULD publish both using the same pubkey when both are enabled.
-
-Clients that discover a server through `kind:11316` SHOULD also fetch `kind:0` for richer profile presentation.
-
-### Publishing Behavior
-
-Profile publication is opt-in.
-
-When configured, servers SHOULD publish their `kind:0` profile metadata at startup and MAY republish on profile changes according to replaceable-event behavior.
-
-## Client Rendering
-
-When both profile sources are available:
-
-- Clients SHOULD prefer `kind:0` metadata for profile presentation
-- Clients SHOULD use `kind:11316` tags as fallback when `kind:0` is absent
-
-This preference order allows clients to display richer identity information while maintaining compatibility with announcement-only servers.
+These event kinds serve different protocol purposes. `kind:11316` remains the ContextVM discoverability surface, while `kind:0` and optional `kind:1` notes support social presence and communication.
 
 ## Backward Compatibility
 
@@ -94,7 +71,7 @@ This CEP is additive and introduces no breaking changes:
 
 - Servers not publishing `kind:0` continue to work unchanged
 - Existing CEP-6 discovery remains valid
-- Clients can progressively enhance rendering when `kind:0` is present
+- Servers can adopt `kind:0` and optional `kind:1` publication incrementally
 
 ## Reference Implementation
 

--- a/src/content/docs/spec/ceps/cep-24.md
+++ b/src/content/docs/spec/ceps/cep-24.md
@@ -62,7 +62,7 @@ Tag intent:
 
 ### Reply to a Comment
 
-Replies MUST reference the parent comment event and use comment-kind context (`1111`).
+Replies MUST reference the parent comment event with lowercase `e`, `k` (set to `1111`), and `p` tags representing the parent comment context, while keeping the uppercase `A`, `K` (set to `11316`), and `P` tags pointed to the root server announcement.
 
 ```json
 {
@@ -79,6 +79,8 @@ Replies MUST reference the parent comment event and use comment-kind context (`1
 }
 ```
 
+*Note: Dual-tagging of `A` and `a` is only applicable to top-level comments where the root and parent are the same. For replies, the parent is a comment event, so the reply MUST use an `e` tag for the parent reference and an `A` tag for the root announcement.*
+
 ### Discovery Filter
 
 Clients discovering reviews for a specific server SHOULD query with:
@@ -87,11 +89,11 @@ Clients discovering reviews for a specific server SHOULD query with:
 {
   "kinds": [1111],
   "#K": ["11316"],
-  "#a": ["11316:<server-pubkey>:"]
+  "#A": ["11316:<server-pubkey>:"]
 }
 ```
 
-Clients MAY additionally query lowercase-only variants where needed for compatibility with relay/client behavior.
+Clients SHOULD query using the uppercase `#A` target tag to discover both top-level reviews and threaded replies. To ensure maximum compatibility with older implementations that might only use lowercase tags for top-level comments, clients MAY optionally include `#a` in their query filters.
 
 ## Moderation Considerations
 
@@ -118,6 +120,10 @@ This CEP is additive:
 - no new ContextVM-specific review kind is introduced
 - clients that already support NIP-22 comments can adopt this targeting convention incrementally
 - servers without review support continue to operate unchanged
+
+## Reference Implementation
+
+A reference implementation for server review UI and data fetching can be found in the [ContextVM site repository](https://github.com/ContextVM/contextvm-site).
 
 ## Dependencies
 

--- a/src/content/docs/spec/ceps/cep-24.md
+++ b/src/content/docs/spec/ceps/cep-24.md
@@ -1,9 +1,9 @@
 ---
-title: CEP-24 Server Reviews via NIP-22
+title: CEP-24 Server Reviews
 description: Standard server reviews using kind 1111 comments on kind 11316 announcements
 ---
 
-# Server Reviews via NIP-22
+# Server Reviews
 
 **Status:** Draft
 **Author:** @contextvm-org
@@ -92,26 +92,6 @@ Clients discovering reviews for a specific server SHOULD query with:
   "#A": ["11316:<server-pubkey>:"]
 }
 ```
-
-Clients SHOULD query using the uppercase `#A` target tag to discover both top-level reviews and threaded replies. To ensure maximum compatibility with older implementations that might only use lowercase tags for top-level comments, clients MAY optionally include `#a` in their query filters.
-
-## Moderation Considerations
-
-Review consumers SHOULD apply moderation controls, including:
-
-- trust-scoring or reputation weighting
-- user-level muting and blocklists
-- report flows and abuse handling
-
-Raw chronological display without moderation signals is discouraged for production UX.
-
-## Spam Resistance
-
-Implementations SHOULD apply anti-spam controls to review ingestion and ranking:
-
-- validate that `a`/`A` tags correctly reference `11316:<server-pubkey>:`
-- apply NIP-13 proof-of-work thresholds where appropriate
-- incorporate Web-of-Trust or local trust scoring before amplification
 
 ## Backward Compatibility
 

--- a/src/content/docs/spec/ceps/cep-24.md
+++ b/src/content/docs/spec/ceps/cep-24.md
@@ -1,0 +1,124 @@
+---
+title: CEP-24 Server Reviews via NIP-22
+description: Standard server reviews using kind 1111 comments on kind 11316 announcements
+---
+
+# Server Reviews via NIP-22
+
+**Status:** Draft
+**Author:** @contextvm-org
+**Type:** Standards Track
+
+## Abstract
+
+This CEP standardizes server reviews by using NIP-22 comments (`kind:1111`) as review events attached to ContextVM server announcements (`kind:11316`).
+
+By reusing NIP-22 comment semantics, reviews become interoperable across clients and relays without requiring a ContextVM-specific review event kind.
+
+## Motivation
+
+ContextVM needs a discovery-friendly, ecosystem-compatible way to publish and retrieve server feedback.
+
+Using NIP-22 comments enables:
+
+- shared review discovery across clients
+- threaded discussion and replies
+- compatibility with existing moderation and anti-spam patterns
+
+The target object for reviews is the server announcement identity (`a` coordinate for `kind:11316`), optionally anchored to the current announcement event (`e`) for better UX and context.
+
+## Specification
+
+### Review Event Kind
+
+Servers and clients MUST use NIP-22 comments (`kind:1111`) for review events.
+
+### Top-Level Comment on a Server
+
+Top-level server reviews SHOULD include both uppercase and lowercase tags as used in NIP-22 ecosystems for broad compatibility.
+
+```json
+{
+  "kind": 1111,
+  "content": "Great server!",
+  "tags": [
+    ["A", "11316:<server-pubkey>:", "<relay-hint>"],
+    ["K", "11316"],
+    ["P", "<server-pubkey>", "<relay-hint>"],
+    ["a", "11316:<server-pubkey>:", "<relay-hint>"],
+    ["e", "<current-announcement-event-id>", "<relay-hint>", "<server-pubkey>"],
+    ["k", "11316"],
+    ["p", "<server-pubkey>", "<relay-hint>"]
+  ]
+}
+```
+
+Tag intent:
+
+- `A` / `a`: addressable target (`11316:<server-pubkey>:`)
+- `K` / `k`: target kind context (`11316` for top-level server review)
+- `P` / `p`: target author context (server pubkey)
+- optional `e`: explicit anchor to the latest known announcement event for timeline context
+
+### Reply to a Comment
+
+Replies MUST reference the parent comment event and use comment-kind context (`1111`).
+
+```json
+{
+  "kind": 1111,
+  "content": "I agree!",
+  "tags": [
+    ["A", "11316:<server-pubkey>:", "<relay-hint>"],
+    ["K", "11316"],
+    ["P", "<server-pubkey>", "<relay-hint>"],
+    ["e", "<parent-comment-event-id>", "<relay-hint>", "<parent-author-pubkey>"],
+    ["k", "1111"],
+    ["p", "<parent-author-pubkey>", "<relay-hint>"]
+  ]
+}
+```
+
+### Discovery Filter
+
+Clients discovering reviews for a specific server SHOULD query with:
+
+```json
+{
+  "kinds": [1111],
+  "#K": ["11316"],
+  "#a": ["11316:<server-pubkey>:"]
+}
+```
+
+Clients MAY additionally query lowercase-only variants where needed for compatibility with relay/client behavior.
+
+## Moderation Considerations
+
+Review consumers SHOULD apply moderation controls, including:
+
+- trust-scoring or reputation weighting
+- user-level muting and blocklists
+- report flows and abuse handling
+
+Raw chronological display without moderation signals is discouraged for production UX.
+
+## Spam Resistance
+
+Implementations SHOULD apply anti-spam controls to review ingestion and ranking:
+
+- validate that `a`/`A` tags correctly reference `11316:<server-pubkey>:`
+- apply NIP-13 proof-of-work thresholds where appropriate
+- incorporate Web-of-Trust or local trust scoring before amplification
+
+## Backward Compatibility
+
+This CEP is additive:
+
+- no new ContextVM-specific review kind is introduced
+- clients that already support NIP-22 comments can adopt this targeting convention incrementally
+- servers without review support continue to operate unchanged
+
+## Dependencies
+
+- [CEP-6: Public Server Announcements](/spec/ceps/cep-6)


### PR DESCRIPTION
## Summary

This PR introduces two new Standards Track draft CEPs:

- **CEP-23:** Server Profile Metadata
- **CEP-24:** Server Reviews via NIP-22

The drafts follow existing CEP style and codify protocol expectations for identity metadata and review discovery.

## Problem

- **CEP-23** needed a formal spec defining optional server identity metadata (kind 0) and client rendering preference rules.
- **CEP-24** needed a formal spec defining interoperable server review discovery using NIP-22 comments on server announcement identities.
- Without draft specs, implementations may diverge in tag usage, discovery filters, moderation assumptions, and fallback behavior.

## Design

- **Added CEP-23 draft covering:**
  - abstract and motivation for kind 0 server identity
  - NIP-01-compatible metadata fields
  - optional ContextVM marker field
  - relationship to CEP-6 capability announcements
  - client rendering preference and fallback guidance
  - startup publication behavior as opt-in
- **Added CEP-24 draft covering:**
  - NIP-22 `kind 1111` review model for servers
  - top-level review and reply tag patterns
  - discovery filter guidance
  - moderation and spam-resistance considerations
  - compatibility and dependency framing

## Key Files

- `cep-23.md`
- `cep-24.md`

## Test Evidence

- **Docs build validation completed successfully:**
  - `bun run build`: success
- **Generated pages include:**
  - `/spec/ceps/cep-23`
  - `/spec/ceps/cep-24`

---

Closes #23
Closes #24
