### PR TITLE
Improve hero external links hover feedback and spacing

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -69,3 +69,21 @@ import IconLinkCard from '../../components/IconLinkCard.astro';
     target="_self"
   />
 </CardGrid>
+
+<style is:global>{`
+  @layer starlight.components {
+    .hero .actions .sl-link-button.minimal {
+      color: var(--sl-color-white);
+      text-decoration: none;
+      text-underline-offset: 0.2em;
+      transition: color 0.2s ease, text-decoration-color 0.2s ease;
+    }
+
+    .hero .actions .sl-link-button.minimal:hover,
+    .hero .actions .sl-link-button.minimal:focus-visible {
+      color: #c084fc;
+      text-decoration: underline;
+      text-decoration-color: currentColor;
+    }
+  }
+`}</style>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -79,11 +79,20 @@ import IconLinkCard from '../../components/IconLinkCard.astro';
       transition: color 0.2s ease, text-decoration-color 0.2s ease;
     }
 
+    .hero .actions .sl-link-button.minimal svg {
+      transition: transform 0.2s ease;
+    }
+
     .hero .actions .sl-link-button.minimal:hover,
     .hero .actions .sl-link-button.minimal:focus-visible {
       color: #c084fc;
       text-decoration: underline;
       text-decoration-color: currentColor;
+    }
+
+    .hero .actions .sl-link-button.minimal:hover svg,
+    .hero .actions .sl-link-button.minimal:focus-visible svg {
+      transform: translateX(0.2rem);
     }
   }
 `}</style>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -94,5 +94,15 @@ import IconLinkCard from '../../components/IconLinkCard.astro';
     .hero .actions .sl-link-button.minimal:focus-visible svg {
       transform: translateX(0.2rem);
     }
+
+    .hero .actions .sl-link-button.minimal + .sl-link-button.minimal {
+      margin-inline-start: 0.75rem;
+    }
+
+    @media (max-width: 50rem) {
+      .hero .actions .sl-link-button.minimal + .sl-link-button.minimal {
+        margin-inline-start: 1rem;
+      }
+    }
   }
 `}</style>


### PR DESCRIPTION
## Summary
Adds clear hover and focus feedback for View on GitHub and Visit the Website on the homepage hero.
Adds smooth 200ms transition for color and underline.
Adds subtle right-shift animation for the external arrow icon.
Improves spacing between the two minimal links, including better mobile spacing.
Keeps the change strictly scoped to this issue only.

## Why this change

Current hero minimal links had no clear hover feedback.
Link spacing felt tight, especially on smaller screens.

## Local verification

Ran locally with Bun and verified on homepage.
Confirmed hover color update to #c084fc.
Confirmed underline appears on hover/focus.
Confirmed arrow moves slightly to the right.
Confirmed spacing improvement between both links on desktop and mobile.

issues #29 

<img width="1298" height="479" alt="image" src="https://github.com/user-attachments/assets/891d3d54-31b6-404c-ac03-21c39123890c" />
