### PR TITLE
Fix missing icons in Core Concepts cards (Payments and CVMI CLI)

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -56,7 +56,7 @@ import IconLinkCard from '../../components/IconLinkCard.astro';
   />
   <IconLinkCard
     title="Payments"
-    icon="credit-card"
+    icon="document"
     href="ts-sdk/payments/overview/"
     description="Add CEP-8 payments to servers and clients with Lightning, NWC, and custom rails"
     target="_blank"

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -63,7 +63,7 @@ import IconLinkCard from '../../components/IconLinkCard.astro';
   />
   <IconLinkCard
     title="CVMI CLI"
-    icon="terminal"
+    icon="laptop"
     href="cvmi/overview/"
     description="Use the CVMI CLI tool - the swiss army knife for ContextVM development"
     target="_self"

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -56,7 +56,7 @@ import IconLinkCard from '../../components/IconLinkCard.astro';
   />
   <IconLinkCard
     title="Payments"
-    icon="document"
+    icon="nostr"
     href="ts-sdk/payments/overview/"
     description="Add CEP-8 payments to servers and clients with Lightning, NWC, and custom rails"
     target="_blank"


### PR DESCRIPTION
## Summary:
On the docs homepage, the Payments and CVMI CLI cards in the Core Concepts section were showing blank icon containers due to unsupported icon names.

## What changed:

Updated Payments card icon to a supported icon.
Updated CVMI CLI card icon to a supported icon.
Kept layout, styles, and content unchanged.
## Validation:

Local production build completed successfully.
Verified both cards now render visible SVG icons in built output.

## Before
<img width="1356" height="713" alt="image" src="https://github.com/user-attachments/assets/2dc445a3-324b-46cc-8f56-41476e9feeb1" />


## After

<img width="1356" height="713" alt="image" src="https://github.com/user-attachments/assets/4e354c9c-d0bd-45cd-8138-dd6f26df33e0" />


Closes #31