### PR TITLE
feat: improve hero get started CTA prominence

### DIFF
--- a/src/components/HeroGetStartedCTAStyles.astro
+++ b/src/components/HeroGetStartedCTAStyles.astro
@@ -1,0 +1,39 @@
+---
+---
+
+<style is:global>
+  .hero .actions .sl-link-button.hero-get-started-cta {
+    font-size: var(--sl-text-base);
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    padding: 0.75rem 1.5rem;
+    border-color: transparent;
+    background: linear-gradient(135deg, var(--sl-color-accent) 0%, var(--sl-color-accent-high) 100%);
+    color: var(--sl-color-black);
+    box-shadow: 0 10px 24px hsla(224, 90%, 60%, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.22s ease, filter 0.22s ease;
+  }
+
+  .hero .actions .sl-link-button.hero-get-started-cta:hover,
+  .hero .actions .sl-link-button.hero-get-started-cta:focus-visible {
+    transform: translateY(-2px) scale(1.04);
+    box-shadow: 0 16px 34px hsla(224, 90%, 60%, 0.45);
+    filter: saturate(1.08);
+    color: var(--sl-color-black);
+  }
+
+  .hero .actions .sl-link-button.hero-get-started-cta :global(svg) {
+    transition: transform 0.2s ease;
+  }
+
+  .hero .actions .sl-link-button.hero-get-started-cta:hover :global(svg),
+  .hero .actions .sl-link-button.hero-get-started-cta:focus-visible :global(svg) {
+    transform: translateX(2px);
+  }
+
+  @media (min-width: 50rem) {
+    .hero .actions .sl-link-button.hero-get-started-cta {
+      padding: 1rem 1.85rem;
+    }
+  }
+</style>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -10,6 +10,8 @@ hero:
     - text: Get Started
       link: getting-started/quick-overview/
       icon: right-arrow
+      attrs:
+        class: hero-get-started-cta
     - text: View on GitHub
       link: https://github.com/contextvm/ts-sdk
       icon: external
@@ -22,6 +24,9 @@ hero:
 
 import { CardGrid } from '@astrojs/starlight/components';
 import IconLinkCard from '../../components/IconLinkCard.astro';
+import HeroGetStartedCTAStyles from '../../components/HeroGetStartedCTAStyles.astro';
+
+<HeroGetStartedCTAStyles />
 
 ## Core Concepts
 


### PR DESCRIPTION
## Summary
Enhance the primary "Get Started" CTA button in the hero section so it stands out more clearly as the main action.

## Changes Made
- Added a dedicated class to the hero primary action for targeted styling.
- Increased CTA visual prominence with larger sizing and stronger emphasis.
- Improved hover/focus interaction with subtle scale and shadow animation.
- Kept existing hero minimal-link styling from upstream intact.

## Scope
- Focused only on hero CTA improvement requested in issue #36.
- No unrelated functional changes.

## Validation
- Local build passed with Bun:
  - bun run build

# Issue
Closes #36


## 
<img width="739" height="367" alt="image" src="https://github.com/user-attachments/assets/38290229-b4b5-4725-9628-449d6cad9a5d" />
