### PR TITLE
docs(cep-6): add publishing guide and discovery tags impact reference

### DIFF
--- a/src/content/docs/spec/ceps/cep-6.md
+++ b/src/content/docs/spec/ceps/cep-6.md
@@ -15,6 +15,16 @@ This CEP proposes a public server discovery mechanism for ContextVM using Nostr 
 
 This CEP also defines the discovery tag set that servers MAY replay on the first direct response sent to a client session. Public announcements remain the canonical public discoverability mechanism, while direct-response replay improves interoperability for stateless or announcement-agnostic clients.
 
+## Publishing Your Server
+
+To have your server appear in ContextVM server listings, publish a kind `11316` 
+announcement event to a Nostr relay that ContextVM listens to.
+
+The fastest way is the CVMI CLI:
+
+```bash
+npx cvmi serve -- <your-server-command>
+```
 ## Specification
 
 ### Overview
@@ -83,11 +93,15 @@ The `content` field contains structured server information following the [MCP sp
 
 The `tags` field provides additional metadata for discoverability:
 
-- **name**: Human-readable server name
-- **about**: Server description
-- **picture**: URL to server icon/avatar
-- **website**: Server website URL
-- **support_encryption**: Indicates server supports encrypted messages
+| Tag | Type | Description | Impact if omitted |
+|---|---|---|---|
+| `name` | string | Display name for your server | Falls back to `serverInfo.name` from capabilities, often a raw technical identifier |
+| `about` | string | What your server does | No description shown in listings, users cannot evaluate your server without clicking in |
+| `picture` | string (URL) | Avatar or icon | A colour block generated from your pubkey is shown instead |
+| `website` | string (URL) | Your homepage or docs | No link shown, users have no way to learn more or verify who runs this server |
+| `support_encryption` | flag | Include this tag if your server supports NIP-44 encryption | Server appears as unencrypted regardless of actual capability |
+
+None of these tags are required by the protocol. Servers that omit `name` and `about` will appear with significantly reduced context in discovery interfaces.
 
 These discovery tags are not limited to public announcement events. Servers MAY also include the same standard and custom discovery tags on the first direct response sent to a client session so that stateless clients can learn server metadata and transport capabilities without first fetching public announcements.
 


### PR DESCRIPTION
CEP-6 is a great protocol spec, but it's written for implementers, not for the server operators who land on it asking one simple question: **"How do I get my server listed on contextvm.org?"**

The current doc never answers that directly. It describes the mechanism but not the action.

There's also a second problem visible on the live site right now, several servers appear as anonymous coloured blocks with no name, no description, and no image. Not because operators intended this, but because nothing in the spec communicates what filling in these tags actually does for their listing.

---

This PR makes two small additions:

**1. Publishing Your Server**: a short section added between the Abstract and Specification that gives operators a direct path to getting listed, using the CVMI CLI.

**2. Discovery Tags Table**: replaces the existing five-line bullet list with a structured table that includes an "Impact if omitted" column, showing operators exactly what their listing looks like on contextvm.org when each field is skipped.

The table doesn't add new requirements to the protocol. It just makes the consequence of skipping these fields visible at the moment operators are deciding what to fill in.

---

Related to #23.

<img width="3792" height="2080" alt="image" src="https://github.com/user-attachments/assets/b8b08f47-cb5d-44c8-81c2-cbafe0b97404" />