### PR TITLE
docs: fix relay in docs to relay.contextvm.org

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1733,7 +1733,7 @@ import { NostrClientTransport } from "@contextvm/sdk";
 // 1. Define the list of relays you want to connect to
 const myRelays = [
   "wss://relay.damus.io",
-  "wss://relay.contextvm.net",
+  "wss://relay.contextvm.org",
   "wss://nos.lol",
 ];
 
@@ -2040,7 +2040,7 @@ import { NostrClientTransport } from "@contextvm/sdk";
 // 1. Define the list of relays you want to connect to
 const myRelays = [
   "wss://relay.damus.io",
-  "wss://relay.contextvm.net",
+  "wss://relay.contextvm.org",
   "wss://nos.lol",
 ];
 

--- a/src/content/docs/how-to/bridge-mcp-server.md
+++ b/src/content/docs/how-to/bridge-mcp-server.md
@@ -38,7 +38,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 
 async function main() {
   const signer = new PrivateKeySigner("your-gateway-private-key-hex");
-  const pool = new ApplesauceRelayPool(["wss://relay.contextvm.net"]);
+  const pool = new ApplesauceRelayPool(["wss://relay.contextvm.org"]);
 
   // 1. Define how to reach your existing server
   const localMcpTransport = new StdioClientTransport({

--- a/src/content/docs/how-to/encryption.md
+++ b/src/content/docs/how-to/encryption.md
@@ -85,7 +85,7 @@ use contextvm_sdk::{EncryptionMode, GiftWrapMode};
 use contextvm_sdk::transport::client::NostrClientTransportConfig;
 
 let config = NostrClientTransportConfig::default()
-    .with_relay_urls(vec!["wss://relay.contextvm.net".to_string()])
+    .with_relay_urls(vec!["wss://relay.contextvm.org".to_string()])
     .with_server_pubkey("<server-pubkey>")
     .with_encryption_mode(EncryptionMode::Required)
     .with_gift_wrap_mode(GiftWrapMode::Ephemeral);

--- a/src/content/docs/reference/rs-sdk/discovery.md
+++ b/src/content/docs/reference/rs-sdk/discovery.md
@@ -31,7 +31,7 @@ use contextvm_sdk::signer;
 #[tokio::main]
 async fn main() -> contextvm_sdk::Result<()> {
     let keys = signer::generate();
-    let relays = vec!["wss://relay.contextvm.net".to_string()];
+    let relays = vec!["wss://relay.contextvm.org".to_string()];
 
     let relay_pool = RelayPool::new(keys).await?;
     relay_pool.connect(&relays).await?;

--- a/src/content/docs/reference/rs-sdk/encryption.md
+++ b/src/content/docs/reference/rs-sdk/encryption.md
@@ -62,7 +62,7 @@ use contextvm_sdk::core::types::{EncryptionMode, GiftWrapMode};
 use contextvm_sdk::transport::client::NostrClientTransportConfig;
 
 let config = NostrClientTransportConfig::default()
-    .with_relay_urls(vec!["wss://relay.contextvm.net".to_string()])
+    .with_relay_urls(vec!["wss://relay.contextvm.org".to_string()])
     .with_server_pubkey("<server-hex-pubkey>")
     .with_encryption_mode(EncryptionMode::Optional)
     .with_gift_wrap_mode(GiftWrapMode::Optional);

--- a/src/content/docs/reference/rs-sdk/gateway.md
+++ b/src/content/docs/reference/rs-sdk/gateway.md
@@ -36,7 +36,7 @@ async fn main() -> contextvm_sdk::Result<()> {
     let keys = signer::generate();
 
     let nostr_config = NostrServerTransportConfig::default()
-        .with_relay_urls(vec!["wss://relay.contextvm.net".to_string()])
+        .with_relay_urls(vec!["wss://relay.contextvm.org".to_string()])
         .with_server_info(
             ServerInfo::default()
                 .with_name("Echo Server".to_string())

--- a/src/content/docs/reference/rs-sdk/proxy.md
+++ b/src/content/docs/reference/rs-sdk/proxy.md
@@ -46,7 +46,7 @@ async fn main() -> contextvm_sdk::Result<()> {
     let keys = signer::from_sk("<hex-or-nsec-private-key>")?;
 
     let nostr_config = NostrClientTransportConfig::default()
-        .with_relay_urls(vec!["wss://relay.contextvm.net".to_string()])
+        .with_relay_urls(vec!["wss://relay.contextvm.org".to_string()])
         .with_server_pubkey("<server-hex-pubkey>");
 
     let config = ProxyConfig::new(nostr_config);

--- a/src/content/docs/reference/rs-sdk/transports.md
+++ b/src/content/docs/reference/rs-sdk/transports.md
@@ -47,7 +47,7 @@ async fn main() -> contextvm_sdk::Result<()> {
     let mut transport = NostrClientTransport::new(
         keys,
         NostrClientTransportConfig::default()
-            .with_relay_urls(vec!["wss://relay.contextvm.net".to_string()])
+            .with_relay_urls(vec!["wss://relay.contextvm.org".to_string()])
             .with_server_pubkey("<server-hex-pubkey>"),
     )
     .await?;

--- a/src/content/docs/reference/ts-sdk/transports/base-nostr-transport.md
+++ b/src/content/docs/reference/ts-sdk/transports/base-nostr-transport.md
@@ -75,7 +75,7 @@ import { ApplesauceRelayPool } from "@contextvm/sdk";
 
 const relayHandler = new ApplesauceRelayPool([
   "wss://relay.damus.io",
-  "wss://relay.contextvm.net",
+  "wss://relay.contextvm.org",
 ]);
 
 const transport = new NostrClientTransport({
@@ -91,7 +91,7 @@ For simple use cases, pass an array of relay URLs and the transport will create 
 ```typescript
 const transport = new NostrClientTransport({
   signer,
-  relayHandler: ["wss://relay.damus.io", "wss://relay.contextvm.net"],
+  relayHandler: ["wss://relay.damus.io", "wss://relay.contextvm.org"],
 });
 ```
 

--- a/src/content/docs/tutorials/build-a-public-server.md
+++ b/src/content/docs/tutorials/build-a-public-server.md
@@ -19,7 +19,7 @@ You will create a minimal ContextVM server that:
 
 - Node.js or Bun
 - A Nostr private key (in hex format)
-- Access to Nostr relays (e.g., `wss://relay.contextvm.net`)
+- Access to Nostr relays (e.g., `wss://relay.contextvm.org`)
 - You have completed the [Client-Server Communication](/tutorials/client-server-communication) tutorial.
 
 ---
@@ -42,7 +42,7 @@ import { z } from "zod";
 // Configuration
 const SERVER_PRIVATE_KEY_HEX =
   process.env.SERVER_PRIVATE_KEY || "your-32-byte-hex-key";
-const RELAYS = ["wss://relay.contextvm.net"];
+const RELAYS = ["wss://relay.contextvm.org"];
 
 async function main() {
   const signer = new PrivateKeySigner(SERVER_PRIVATE_KEY_HEX);
@@ -113,7 +113,7 @@ You can verify your server is discoverable by querying the relays for a `kind: 1
 
 ```bash
 # Example using nak (the standard Nostr CLI)
-nak req -k 11316 -a <your-server-pubkey> wss://relay.contextvm.net
+nak req -k 11316 -a <your-server-pubkey> wss://relay.contextvm.org
 ```
 
 ## Step 4: Remove announcements

--- a/src/content/docs/tutorials/client-server-communication.md
+++ b/src/content/docs/tutorials/client-server-communication.md
@@ -37,7 +37,7 @@ import { z } from "zod";
 // IMPORTANT: Replace with your own private key
 const SERVER_PRIVATE_KEY_HEX =
   process.env.SERVER_PRIVATE_KEY || "your-32-byte-server-private-key-in-hex";
-const RELAYS = ["wss://relay.contextvm.net", "wss://nos.lol"];
+const RELAYS = ["wss://relay.contextvm.org", "wss://nos.lol"];
 
 // --- Main Server Logic ---
 async function main() {
@@ -124,7 +124,7 @@ const SERVER_PUBKEY = "the-public-key-printed-by-server.ts";
 // IMPORTANT: Replace with your own private key
 const CLIENT_PRIVATE_KEY_HEX =
   process.env.CLIENT_PRIVATE_KEY || "your-32-byte-client-private-key-in-hex";
-const RELAYS = ["wss://relay.contextvm.net", "wss://nos.lol"];
+const RELAYS = ["wss://relay.contextvm.org", "wss://nos.lol"];
 
 // --- Main Client Logic ---
 async function main() {

--- a/src/content/docs/tutorials/discover-servers.md
+++ b/src/content/docs/tutorials/discover-servers.md
@@ -27,7 +27,7 @@ Create a file named `discover.ts` and add the following:
 ```typescript
 import { ApplesauceRelayPool } from "@contextvm/sdk";
 
-const RELAYS = ["wss://relay.contextvm.net"];
+const RELAYS = ["wss://relay.contextvm.org"];
 
 async function main() {
   const pool = new ApplesauceRelayPool(RELAYS);
@@ -125,7 +125,7 @@ use contextvm_sdk::discovery;
 use contextvm_sdk::relay::RelayPool;
 
 let pool = RelayPool::new(signer).await?;
-pool.connect(&["wss://relay.contextvm.net".to_string()]).await?;
+pool.connect(&["wss://relay.contextvm.org".to_string()]).await?;
 
 let servers = discovery::discover_servers(pool.client(), &relays).await?;
 

--- a/src/content/docs/tutorials/rust-server-client.md
+++ b/src/content/docs/tutorials/rust-server-client.md
@@ -17,7 +17,7 @@ You will create a Rust binary with two roles:
 ## Prerequisites
 
 - Rust toolchain (`cargo`, `rustc`)
-- Access to a Nostr relay (e.g., `wss://relay.contextvm.net`)
+- Access to a Nostr relay (e.g., `wss://relay.contextvm.org`)
 
 ---
 
@@ -114,7 +114,7 @@ pub async fn run_server() -> anyhow::Result<()> {
     let transport = NostrServerTransport::new(
         signer,
         NostrServerTransportConfig::default()
-            .with_relay_urls(vec!["wss://relay.contextvm.net".to_string()])
+            .with_relay_urls(vec!["wss://relay.contextvm.org".to_string()])
             .with_announced_server(false),
     ).await?;
 
@@ -150,7 +150,7 @@ pub async fn run_client(server_pubkey: String) -> anyhow::Result<()> {
     let transport = NostrClientTransport::new(
         signer,
         NostrClientTransportConfig::default()
-            .with_relay_urls(vec!["wss://relay.contextvm.net".to_string()])
+            .with_relay_urls(vec!["wss://relay.contextvm.org".to_string()])
             .with_server_pubkey(server_pubkey),
     ).await?;
 


### PR DESCRIPTION
- Fixing typo in the relay used in the documentation relay.contextvm.org was instead relay.contextvm.net which does not work